### PR TITLE
Updated the title and tab name

### DIFF
--- a/src/app/components/CataLogHome.tsx
+++ b/src/app/components/CataLogHome.tsx
@@ -65,7 +65,7 @@ const CataLogHome = ({ datasets, models, tools, publications }) => {
               <Tab className="tab-item">Data Sources</Tab>
               <Tab className="tab-item">AI Models</Tab>
               <Tab className="tab-item">Publications</Tab>
-              <Tab className="tab-item">General AI Tools</Tab>
+              <Tab className="tab-item">AI Tools</Tab>
             </TabList>
             <TabPanels>
               <TabPanel>

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -13,7 +13,7 @@ const Header: React.FC = () => {
   return (
     <header className={styles.header}>
       <div className={styles.overlay}>
-        <h1 className={styles.headerTitle}>AI Sustainability Catalog</h1>
+        <h1 className={styles.headerTitle}>AI Sustainability Hub</h1>
         <p className={styles.headerDescription}>
           Your go-to resource for AI models, data sources, tools, and publications for sustainability.
         </p>


### PR DESCRIPTION
This PR addresses the following:
1) Updated the header from Catalog to Hub and made it AI Sustainability Hub 
2) Updated General AI Tools to "AI Tools"